### PR TITLE
Fix cross issue

### DIFF
--- a/pages/api/avo/index.ts
+++ b/pages/api/avo/index.ts
@@ -17,6 +17,8 @@ const allAvos = async (req: IncomingMessage, res: ServerResponse) => {
     // https://nextjs.org/docs/api-routes/response-helpers
     res.statusCode = 200
     res.setHeader('Content-Type', 'application/json')
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'GET')
     res.end(JSON.stringify({ length, data: allEntries }))
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
I've Added Access control allow origin and Access Control Allow Method headers
I will only let the HTTP GET method as a Allow method.
This was because, I was trying to use the API-Avo in my project. But the API did not work without Access-Control-Allow-Origin header.
